### PR TITLE
[scripts] add travis-build.sh and .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+script: ./scripts/travis-build.sh
+env:
+    - PROJECT=beagle-test        TOOLCHAIN=arm-eabi-4.9.0-Linux-x86_64
+    - PROJECT=vexpress-a9-test   TOOLCHAIN=arm-eabi-4.9.0-Linux-x86_64
+    - PROJECT=pc-x86-test        TOOLCHAIN=i386-elf-4.9.0-Linux-x86_64

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Copyright (c) 2014 Eren Türkay <turkay.eren@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+# This is a script for travis-ci that builds lk for different
+# architectures using different toolchains on travis-ci build machine.
+#
+# PROJECT and TOOLCHAIN are provided as environment variables. These
+# variables are specified in .travis.yml file.
+
+TOOLCHAIN_BASE_URL="http://newos.org/toolchains"
+TOOLCHAIN_SUFFIX="tar.xz"
+
+TOOLCHAIN_ADDRESS="$TOOLCHAIN_BASE_URL/$TOOLCHAIN.$TOOLCHAIN_SUFFIX"
+
+echo "Downloading toolchain $TOOLCHAIN from $TOOLCHAIN_ADDRESS"
+wget $TOOLCHAIN_ADDRESS -q
+
+echo "Unpacking $TOOLCHAIN"
+tar xf $TOOLCHAIN.$TOOLCHAIN_SUFFIX
+export PATH=`pwd`/$TOOLCHAIN/bin:$PATH
+
+echo "Starting build '$PROJECT' with '$TOOLCHAIN'\n"
+make $PROJECT


### PR DESCRIPTION
Github provides travis continuous integration service. This change makes it possible to utilize travis with prebuilt toolchains from http://newos.org/toolchains/

The build matrix is defined in .travis.yml file. I don't know to full extend which toolchain should be used for each project. This list need to be extended. If you can provide me with build matrix, I can update the PR.

The sample output for travis can be seen in https://travis-ci.org/eren/lk

Regards,
Eren 