### PR TITLE
[kernel] thread_join from multiple threads

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -301,24 +301,28 @@ status_t thread_join(thread_t *t, int *retcode, lk_time_t timeout)
 	ASSERT(!list_in_list(&t->queue_node));
 #endif
 
-	/* save the return code */
-	if (retcode)
-		*retcode = t->retcode;
+    /* Check if some other thread already reclaimed the thread resources */
+    if (t) {
+        /* save the return code */
+        if (retcode)
+            *retcode = t->retcode;
 
-	/* remove it from the master thread list */
-	list_delete(&t->thread_list_node);
+        /* remove it from the master thread list */
+        list_delete(&t->thread_list_node);
 
-	/* clear the structure's magic */
-	t->magic = 0;
-
+        /* clear the structure's magic */
+        t->magic = 0;
+    }
 	exit_critical_section();
 
 	/* free its stack and the thread structure itself */
-	if (t->flags & THREAD_FLAG_FREE_STACK && t->stack)
-		free(t->stack);
+    if (t) {
+        if (t->flags & THREAD_FLAG_FREE_STACK && t->stack)
+            free(t->stack);
 
-	if (t->flags & THREAD_FLAG_FREE_STRUCT)
-		free(t);
+        if (t->flags & THREAD_FLAG_FREE_STRUCT)
+            free(t);
+    }
 
 	return NO_ERROR;
 }


### PR DESCRIPTION
This patch enables multiple concurrent threads to call thread_join on
a particular thread

In thread_join(), we simply make checks regarding whether the thread
structure has been freed or not.

This could just be a quick fix. A better solution would be to
implement reference counting on thread objects, and free the
resources when the count goes to zero.