### PR TITLE
[vm] search translation table to for phys2virt

### DIFF
--- a/include/arch/mmu.h
+++ b/include/arch/mmu.h
@@ -41,6 +41,7 @@ __BEGIN_CDECLS
 int arch_mmu_map(vaddr_t vaddr, paddr_t paddr, uint count, uint flags);
 int arch_mmu_unmap(vaddr_t vaddr, uint count);
 status_t arch_mmu_query(vaddr_t vaddr, paddr_t *paddr, uint *flags);
+status_t arch_mmu_query_reverse(paddr_t paddr, vaddr_t *vaddr, uint *flags);
 
 void arch_disable_mmu(void);
 

--- a/kernel/vm/vm.c
+++ b/kernel/vm/vm.c
@@ -99,17 +99,13 @@ static void vm_init_postheap(uint level)
 
 void *paddr_to_kvaddr(paddr_t pa)
 {
-    /* slow path to do reverse lookup */
-    struct mmu_initial_mapping *map = mmu_initial_mappings;
-    while (map->size > 0) {
-        if (!(map->flags & MMU_INITIAL_MAPPING_TEMPORARY) &&
-            pa >= map->phys &&
-            pa <= map->phys + map->size) {
-            return (void *)(map->virt + (pa - map->phys));
-        }
-        map++;
-    }
-    return NULL;
+    status_t rc;
+    vaddr_t  va;
+
+    rc = arch_mmu_query_reverse(pa, &va, NULL);
+    if (rc)
+        return NULL;
+    return (void*)va;
 }
 
 paddr_t kvaddr_to_paddr(void *ptr)


### PR DESCRIPTION
this allows us to correctly translate addresses that were not mapped
by the initial table.