### PR TITLE
[vm] allow using null pointers

### DIFF
--- a/arch/arm/arm/mmu.c
+++ b/arch/arm/arm/mmu.c
@@ -333,8 +333,9 @@ int arch_mmu_map(vaddr_t vaddr, paddr_t paddr, uint count, uint flags)
                     break;
                 case MMU_MEMORY_L1_DESCRIPTOR_INVALID: {
                     /* alloc and put in a L2 page table */
-                    uint32_t *l2_table = pmm_alloc_kpage();
-                    if (!l2_table) {
+                    uint32_t *l2_table = NULL;
+                    uint ret = pmm_alloc_kpage((void**)&l2_table);
+                    if (!ret) {
                         TRACEF("failed to allocate pagetable\n");
                         goto done;
                     }

--- a/arch/or1k/mmu.c
+++ b/arch/or1k/mmu.c
@@ -185,8 +185,9 @@ int arch_mmu_map(vaddr_t vaddr, paddr_t paddr, uint count, uint flags)
             l2_table = paddr_to_kvaddr(pte & ~OR1K_MMU_PG_FLAGS_MASK);
             LTRACEF("l2_table at %p\n", l2_table);
         } else {
-            l2_table = pmm_alloc_kpage();
-            if (!l2_table) {
+            l2_table = NULL;
+            uint ret = pmm_alloc_kpage((void**)&l2_table);
+            if (!ret) {
                 TRACEF("failed to allocate pagetable\n");
                 return mapped;
             }

--- a/include/kernel/vm.h
+++ b/include/kernel/vm.h
@@ -131,10 +131,10 @@ uint pmm_alloc_contiguous(uint count, uint8_t align_log2, paddr_t *pa, struct li
     /* Allocate a run of pages out of the kernel area and return the pointer in kernel space.
      * If the optional list is passed, append the allocate page structures to the tail of the list.
      */
-void *pmm_alloc_kpages(uint count, struct list_node *list);
+uint pmm_alloc_kpages(uint count, void **pa, struct list_node *list);
 
     /* Helper routine for pmm_alloc_kpages. */
-static inline void *pmm_alloc_kpage(void) { return pmm_alloc_kpages(1, NULL); }
+static inline uint pmm_alloc_kpage(void **pa) { return pmm_alloc_kpages(1, pa, NULL); }
 
 /* physical to virtual */
 void *paddr_to_kvaddr(paddr_t pa);

--- a/lib/heap/heap.c
+++ b/lib/heap/heap.c
@@ -506,8 +506,9 @@ static ssize_t heap_grow(size_t size)
 #if WITH_KERNEL_VM
 	size = ROUNDUP(size, PAGE_SIZE);
 
-	void *ptr = pmm_alloc_kpages(size / PAGE_SIZE, NULL);
-	if (!ptr)
+	void *ptr = NULL;
+	uint ret = pmm_alloc_kpages(size / PAGE_SIZE, ptr, NULL);
+	if (!ret)
 		return ERR_NO_MEMORY;
 
 	LTRACEF("growing heap by 0x%zx bytes, new ptr %p\n", size, ptr);
@@ -544,10 +545,10 @@ void heap_init(void)
 
 	// set the heap range
 #if WITH_KERNEL_VM
-	theheap.base = pmm_alloc_kpages(HEAP_GROW_SIZE / PAGE_SIZE, NULL);
+	uint ret = pmm_alloc_kpages(HEAP_GROW_SIZE / PAGE_SIZE, &theheap.base, NULL);
 	theheap.len = HEAP_GROW_SIZE;
 
-	if (theheap.base == 0) {
+	if (ret == 0) {
 		panic("HEAP: error allocating initial heap size\n");
 	}
 #else


### PR DESCRIPTION
on devices where SDRAM starts at 0x0 null pointers were treated as a error.
To work around this problem, 'pmm_alloc_kpages' now returns a result code
and stores the allocated address in a void** pointer.