### PR TITLE
Block IO Aligned Buffers

### DIFF
--- a/dev/virtio/block/virtio-block.c
+++ b/dev/virtio/block/virtio-block.c
@@ -154,7 +154,7 @@ status_t virtio_block_init(struct virtio_device *dev, uint32_t host_features)
     snprintf(buf, sizeof(buf), "virtio%u", found_index++);
     bio_initialize_bdev(&bdev->bdev, buf,
                         config->blk_size, config->capacity,
-                        0, NULL);
+                        0, NULL, BIO_FLAGS_NONE);
 
     /* override our block device hooks */
     bdev->bdev.read_block = &virtio_bdev_read_block;

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -53,8 +53,7 @@ long long strtoll(const char *nptr, char **endptr, int base);
 
 /* allocate a buffer on the stack aligned and padded to the cpu's cache line size */
 #define STACKBUF_DMA_ALIGN(var, size) \
-    uint8_t __##var[(size) + CACHE_LINE]; uint8_t *var = (uint8_t *)(ROUNDUP((addr_t)__##var, CACHE_LINE))
-
+	uint8_t var[ROUNDUP(size, CACHE_LINE)] __ALIGNED(CACHE_LINE);
 void abort(void) __attribute__((noreturn));
 void qsort(void *aa, size_t n, size_t es, int (*cmp)(const void *, const void *));
 void *bsearch(const void *key, const void *base, size_t num_elems, size_t size,

--- a/lib/bio/bio.c
+++ b/lib/bio/bio.c
@@ -401,7 +401,8 @@ void bio_initialize_bdev(bdev_t *dev,
                          size_t block_size,
                          bnum_t block_count,
                          size_t geometry_count,
-                         const bio_erase_geometry_info_t* geometry)
+                         const bio_erase_geometry_info_t* geometry,
+                         const uint8_t flags)
 {
     DEBUG_ASSERT(dev);
     DEBUG_ASSERT(name);
@@ -419,6 +420,7 @@ void bio_initialize_bdev(bdev_t *dev,
     dev->geometry = geometry;
     dev->erase_byte = 0;
     dev->ref = 0;
+    dev->flags = flags;
 
 #if DEBUG
     // If we have been supplied information about our erase geometry, sanity

--- a/lib/bio/bio.c
+++ b/lib/bio/bio.c
@@ -61,7 +61,7 @@ static ssize_t bio_default_read(struct bdev *dev, void *_buf, off_t offset, size
         err = bio_read_block(dev, temp, block, 1);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size) {
+        } else if ((size_t)err != dev->block_size) {
             err = ERR_IO;
             goto err;
         }
@@ -91,7 +91,7 @@ static ssize_t bio_default_read(struct bdev *dev, void *_buf, off_t offset, size
             err = bio_read_block(dev, temp, block, 1);
             if (err < 0) {
                 goto err;
-            } else if (err != dev->block_size) {
+            } else if ((size_t)err != dev->block_size) {
                 err = ERR_IO;
                 goto err;
             }
@@ -107,7 +107,7 @@ static ssize_t bio_default_read(struct bdev *dev, void *_buf, off_t offset, size
         err = bio_read_block(dev, buf, block, num_blocks);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size * num_blocks) {
+        } else if ((size_t)err != dev->block_size * num_blocks) {
             err = ERR_IO;
             goto err;
         }
@@ -124,7 +124,7 @@ static ssize_t bio_default_read(struct bdev *dev, void *_buf, off_t offset, size
         err = bio_read_block(dev, temp, block, 1);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size) {
+        } else if ((size_t)err != dev->block_size) {
             err = ERR_IO;
             goto err;
         }
@@ -158,7 +158,7 @@ static ssize_t bio_default_write(struct bdev *dev, const void *_buf, off_t offse
         err = bio_read_block(dev, temp, block, 1);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size) {
+        } else if ((size_t)err != dev->block_size) {
             err = ERR_IO;
             goto err;
         }
@@ -172,7 +172,7 @@ static ssize_t bio_default_write(struct bdev *dev, const void *_buf, off_t offse
         err = bio_write_block(dev, temp, block, 1);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size) {
+        } else if ((size_t)err != dev->block_size) {
             err = ERR_IO;
             goto err;
         }
@@ -199,7 +199,7 @@ static ssize_t bio_default_write(struct bdev *dev, const void *_buf, off_t offse
             err = bio_write_block(dev, temp, block, 1);
             if (err < 0) {
                 goto err;
-            } else if (err != dev->block_size) {
+            } else if ((size_t)err != dev->block_size) {
                 err = ERR_IO;
                 goto err;
             }
@@ -214,7 +214,7 @@ static ssize_t bio_default_write(struct bdev *dev, const void *_buf, off_t offse
         err = bio_write_block(dev, buf, block, block_count);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size * block_count) {
+        } else if ((size_t)err != dev->block_size * block_count) {
             err = ERR_IO;
             goto err;
         }
@@ -234,7 +234,7 @@ static ssize_t bio_default_write(struct bdev *dev, const void *_buf, off_t offse
         err = bio_read_block(dev, temp, block, 1);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size) {
+        } else if ((size_t)err != dev->block_size) {
             err = ERR_IO;
             goto err;
         }
@@ -246,7 +246,7 @@ static ssize_t bio_default_write(struct bdev *dev, const void *_buf, off_t offse
         err = bio_write_block(dev, temp, block, 1);
         if (err < 0) {
             goto err;
-        } else if (err != dev->block_size) {
+        } else if ((size_t)err != dev->block_size) {
             err = ERR_IO;
             goto err;
         }

--- a/lib/bio/debug.c
+++ b/lib/bio/debug.c
@@ -30,6 +30,7 @@
 #include <lib/bio.h>
 #include <lib/partition.h>
 #include <platform.h>
+#include <kernel/thread.h>
 
 #if WITH_LIB_CKSUM
 #include <lib/cksum.h>
@@ -133,10 +134,10 @@ usage:
             return -1;
         }
 
-        uint8_t buf[256];
+        uint8_t* buf = memalign(CACHE_LINE, 256);
         ssize_t err = 0;
         while (len > 0) {
-            size_t  amt = MIN(sizeof(buf), len);
+            size_t  amt = MIN(256, len);
             ssize_t err = bio_read(dev, buf, offset, amt);
 
             if (err < 0) {

--- a/lib/bio/include/lib/bio.h
+++ b/lib/bio/include/lib/bio.h
@@ -26,8 +26,9 @@
 #include <sys/types.h>
 #include <list.h>
 
-#define BIO_FLAGS_NONE                    (0 << 0)
-#define BIO_FLAG_REQUIRES_CACHE_ALIGNMENT (1 << 0)
+#define BIO_FLAGS_NONE                (0 << 0)
+#define BIO_FLAG_CACHE_ALIGNED_READS  (1 << 0)
+#define BIO_FLAG_CACHE_ALIGNED_WRITES (1 << 1)
 
 typedef uint32_t bnum_t;
 
@@ -55,7 +56,7 @@ typedef struct bdev {
 
     uint8_t erase_byte;
 
-    uint8_t flags;
+    uint32_t flags;
 
     /* function pointers */
     ssize_t (*read)(struct bdev *, void *buf, off_t offset, size_t len);

--- a/lib/bio/include/lib/bio.h
+++ b/lib/bio/include/lib/bio.h
@@ -26,6 +26,9 @@
 #include <sys/types.h>
 #include <list.h>
 
+#define BIO_FLAGS_NONE                    (0 << 0)
+#define BIO_FLAG_REQUIRES_CACHE_ALIGNMENT (1 << 0)
+
 typedef uint32_t bnum_t;
 
 typedef struct bio_erase_geometry_info {
@@ -51,6 +54,8 @@ typedef struct bdev {
     const bio_erase_geometry_info_t* geometry;
 
     uint8_t erase_byte;
+
+    uint8_t flags;
 
     /* function pointers */
     ssize_t (*read)(struct bdev *, void *buf, off_t offset, size_t len);
@@ -82,7 +87,8 @@ void bio_initialize_bdev(bdev_t* dev,
                          size_t block_size,
                          bnum_t block_count,
                          size_t geometry_count,
-                         const bio_erase_geometry_info_t* geometry);
+                         const bio_erase_geometry_info_t* geometry,
+                         const uint8_t flags);
 
 /* debug stuff */
 void bio_dump_devices(void);

--- a/lib/bio/mem.c
+++ b/lib/bio/mem.c
@@ -85,7 +85,8 @@ int create_membdev(const char *name, void *ptr, size_t len)
     mem_bdev_t *mem = malloc(sizeof(mem_bdev_t));
 
     /* set up the base device */
-    bio_initialize_bdev(&mem->dev, name, BLOCKSIZE, len / BLOCKSIZE, 0, NULL);
+    bio_initialize_bdev(&mem->dev, name, BLOCKSIZE, len / BLOCKSIZE, 0, NULL,
+                        BIO_FLAGS_NONE);
 
     /* our bits */
     mem->ptr = ptr;

--- a/lib/bio/subdev.c
+++ b/lib/bio/subdev.c
@@ -172,7 +172,7 @@ status_t bio_publish_subdevice(const char *parent_dev,
 
     bio_initialize_bdev(&sub->dev, subdev,
                         parent->block_size, block_count,
-                        geometry_count, geometry);
+                        geometry_count, geometry, BIO_FLAGS_NONE);
 
     sub->parent = parent;
     sub->offset = startblock;

--- a/platform/armemu/blkdev.c
+++ b/platform/armemu/blkdev.c
@@ -78,7 +78,8 @@ void platform_init_blkdev(void)
 	if (get_blkdev_len() == 0)
 		return;
 
-	bio_initialize_bdev(&dev, "block0", 512, get_blkdev_len() / 512, 0, NULL);
+	bio_initialize_bdev(&dev, "block0", 512, get_blkdev_len() / 512, 0, NULL,
+						BIO_FLAGS_NONE);
 
 	// fill in hooks
 	dev.read_block = &read_block;

--- a/platform/stm32f4xx/flash.c
+++ b/platform/stm32f4xx/flash.c
@@ -59,7 +59,8 @@ status_t stmflash_init(uint32_t start, uint32_t length)
                        1,
                   length,
                        0,
-                       NULL);
+                       NULL,
+                       BIO_FLAGS_NONE);
 
     /* override our block device hooks */
     sg_flash.bdev.read        = &stmflash_bdev_read;

--- a/platform/stm32f7xx/flash.c
+++ b/platform/stm32f7xx/flash.c
@@ -89,7 +89,7 @@ void stm32_flash_init(void)
     /* construct the block device */
     bio_initialize_bdev(&flash.bdev, "flash0",
                         PROGRAM_SIZE, flash.size / PROGRAM_SIZE,
-                        3, flash.geometry);
+                        3, flash.geometry, BIO_FLAGS_NONE);
 
     /* we erase to 0xff */
     flash.bdev.erase_byte = 0xff;

--- a/platform/stm32f7xx/qspi.c
+++ b/platform/stm32f7xx/qspi.c
@@ -523,7 +523,7 @@ status_t qspi_flash_init(size_t flash_size)
 
     bio_initialize_bdev(&qspi_flash_device, device_name, N25QXXA_PAGE_SIZE,
                         (flash_size / N25QXXA_PAGE_SIZE), 1, &geometry,
-                         BIO_FLAG_REQUIRES_CACHE_ALIGNMENT);
+                         BIO_FLAG_CACHE_ALIGNED_READS);
 
     // qspi_flash_device.read: Use default hook.
     qspi_flash_device.read_block = &spiflash_bdev_read_block;

--- a/platform/stm32f7xx/qspi.c
+++ b/platform/stm32f7xx/qspi.c
@@ -256,8 +256,8 @@ static ssize_t spiflash_bdev_read_block(struct bdev* device, void* buf,
     LTRACEF("device %p, buf %p, block %u, count %u\n",
             device, buf, block, count);
 
-    if (!IS_ALIGNED((size_t)buf, CACHE_LINE)) {
-        DEBUG_ASSERT(IS_ALIGNED((size_t)buf, CACHE_LINE));
+    if (!IS_ALIGNED((uintptr_t)buf, CACHE_LINE)) {
+        DEBUG_ASSERT(IS_ALIGNED((uintptr_t)buf, CACHE_LINE));
         return ERR_INVALID_ARGS;
     }
 
@@ -669,8 +669,8 @@ static HAL_StatusTypeDef qspi_tx_dma(QSPI_HandleTypeDef* qspi_handle, QSPI_Comma
 static HAL_StatusTypeDef qspi_rx_dma(QSPI_HandleTypeDef* qspi_handle, QSPI_CommandTypeDef* s_command, uint8_t* buf)
 {
     // Make sure the front and back of the buffer are cache aligned.
-    DEBUG_ASSERT(IS_ALIGNED((size_t)buf, CACHE_LINE));
-    DEBUG_ASSERT(IS_ALIGNED(((size_t)buf) + s_command->NbData, CACHE_LINE));
+    DEBUG_ASSERT(IS_ALIGNED((uintptr_t)buf, CACHE_LINE));
+    DEBUG_ASSERT(IS_ALIGNED(((uintptr_t)buf) + s_command->NbData, CACHE_LINE));
 
     arch_invalidate_cache_range((addr_t)buf, s_command->NbData);
 

--- a/platform/stm32f7xx/qspi.c
+++ b/platform/stm32f7xx/qspi.c
@@ -513,7 +513,8 @@ status_t qspi_flash_init(size_t flash_size)
     geometry.size = flash_size;
 
     bio_initialize_bdev(&qspi_flash_device, device_name, N25QXXA_PAGE_SIZE,
-                        (flash_size / N25QXXA_PAGE_SIZE), 1, &geometry);
+                        (flash_size / N25QXXA_PAGE_SIZE), 1, &geometry,
+                         BIO_FLAG_REQUIRES_CACHE_ALIGNMENT);
 
     qspi_flash_device.read = &spiflash_bdev_read;
     qspi_flash_device.read_block = &spiflash_bdev_read_block;

--- a/platform/zynq/spiflash.c
+++ b/platform/zynq/spiflash.c
@@ -311,7 +311,7 @@ status_t spiflash_detect(void)
 	/* construct the block device */
 	bio_initialize_bdev(&flash.bdev, "spi0",
 						PAGE_PROGRAM_SIZE, flash.size / PAGE_PROGRAM_SIZE,
-						region_count, flash.geometry);
+						region_count, flash.geometry, BIO_FLAGS_NONE);
 
 	/* override our block device hooks */
 	flash.bdev.read = &spiflash_bdev_read;


### PR DESCRIPTION
+ Add a flags field inside `bdev_t`
+ Allow devices to mark themselves as requiring cache aligned buffers
+ [STM32F7 Spiflash] require cache aligned buffers
+ [STM32F7 Spiflash] use default implementation for `bio_read`
+ Don't allocate on the stack for `bio dump` since this blows the stack