### PR TITLE
[arch][x86_64][fpu]use correct initial fpu states when each thread is created

### DIFF
--- a/arch/x86-64/include/arch/fpu.h
+++ b/arch/x86-64/include/arch/fpu.h
@@ -22,8 +22,11 @@
 */
 
 #include <kernel/thread.h>
+#include <stdlib.h>
+#include <string.h>
 
 void fpu_init(void);
+void fpu_init_thread_states(thread_t *t);
 void fpu_context_switch(thread_t *old_thread, thread_t *new_thread);
 void fpu_dev_na_handler(void);
 

--- a/arch/x86-64/thread.c
+++ b/arch/x86-64/thread.c
@@ -72,8 +72,7 @@ void arch_thread_initialize(thread_t *t)
     /* set the stack pointer */
     t->arch.rsp = (vaddr_t)frame;
 #ifdef X86_WITH_FPU
-    memset(t->arch.fpu_buffer, 0, sizeof(t->arch.fpu_buffer));
-    t->arch.fpu_states = (vaddr_t *)ROUNDUP(((vaddr_t)t->arch.fpu_buffer), 16);
+    fpu_init_thread_states(t);
 #endif
 }
 


### PR DESCRIPTION

Currently, all new thread created with **zero** fpu states (512byte buffer of fxsave area is filled up with 0s), then when a new thread triggers "fpu device not available" exception (lazy fpu algorithm) at the first time, the handler just blindly call fxrstor to fetch all those zero states from fxsave area buffer. This patch is just to guarantee each new thread to have correct initial fpu states. 

Note that x86 fpu code isn't changed in this patch because the 32/64 bit fpu code are 99% duplicated. I assume that they should be merged in future.

BTW, this is not fixing https://github.com/travisg/lk/issues/71 

