### PR TITLE
cmpctmalloc: Tweak bucket sizes to optimize power-of-2 allocs.

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -49,7 +49,7 @@ long long strtoll(const char *nptr, char **endptr, int base);
 #define ROUNDDOWN(a, b) ((a) & ~((b)-1))
 
 #define ALIGN(a, b) ROUNDUP(a, b)
-#define IS_ALIGNED(a, b) (!((a) & ((b)-1)))
+#define IS_ALIGNED(a, b) (!(((uintptr_t)(a)) & (((uintptr_t)(b))-1)))
 
 /* allocate a buffer on the stack aligned and padded to the cpu's cache line size */
 #define STACKBUF_DMA_ALIGN(var, size) \


### PR DESCRIPTION
With this change allocations of > 128 bytes that are powers of two will be allocated at the exact size requested, instead of being subjected to worst-case round-up of 1/8th (12.5%). 

Fix and test heap_trim better.  The tests now do trims with tricky free sizes at the start and end of OS allocation areas (just around 1 page).

Add an assert for the most obvious double frees in debug mode.