### PR TITLE
[arch][x86][x64][fpu]fix compile error when X86_WITH_FPU is not defined.

### DIFF
--- a/arch/x86-64/arch.c
+++ b/arch/x86-64/arch.c
@@ -52,7 +52,7 @@ void arch_chain_load(void *entry, ulong arg0, ulong arg1, ulong arg2, ulong arg3
 
 void arch_init(void)
 {
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     fpu_init();
 #endif
 }

--- a/arch/x86-64/fpu.c
+++ b/arch/x86-64/fpu.c
@@ -25,6 +25,8 @@
 #include <arch/fpu.h>
 #include <kernel/thread.h>
 
+#if X86_WITH_FPU
+
 /* CPUID EAX = 1 return values */
 
 #define ECX_SSE3    (0x00000001 << 0)
@@ -153,5 +155,6 @@ void fpu_dev_na_handler(void)
     fp_owner = self;
     return;
 }
+#endif
 
 /* End of file */

--- a/arch/x86-64/include/arch/arch_thread.h
+++ b/arch/x86-64/include/arch/arch_thread.h
@@ -28,7 +28,7 @@
 
 struct arch_thread {
     vaddr_t rsp;
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     vaddr_t *fpu_states;
     uint8_t fpu_buffer[512 + 16];
 #endif

--- a/arch/x86-64/thread.c
+++ b/arch/x86-64/thread.c
@@ -71,7 +71,7 @@ void arch_thread_initialize(thread_t *t)
 
     /* set the stack pointer */
     t->arch.rsp = (vaddr_t)frame;
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     fpu_init_thread_states(t);
 #endif
 }
@@ -86,7 +86,7 @@ void arch_dump_thread(thread_t *t)
 
 void arch_context_switch(thread_t *oldthread, thread_t *newthread)
 {
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     fpu_context_switch(oldthread, newthread);
 #endif
 

--- a/arch/x86/fpu.c
+++ b/arch/x86/fpu.c
@@ -25,6 +25,8 @@
 #include <arch/fpu.h>
 #include <kernel/thread.h>
 
+#if X86_WITH_FPU
+
 /* CPUID EAX = 1 return values */
 
 #define ECX_SSE3    (0x00000001 << 0)
@@ -141,5 +143,6 @@ void fpu_dev_na_handler(void)
     fp_owner = self;
     return;
 }
+#endif
 
 /* End of file */

--- a/arch/x86/include/arch/arch_thread.h
+++ b/arch/x86/include/arch/arch_thread.h
@@ -28,7 +28,7 @@
 
 struct arch_thread {
     vaddr_t esp;
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     vaddr_t *fpu_states;
     uint8_t fpu_buffer[512 + 16];
 #endif

--- a/arch/x86/thread.c
+++ b/arch/x86/thread.c
@@ -88,7 +88,7 @@ void arch_thread_initialize(thread_t *t)
 
     // set the stack pointer
     t->arch.esp = (vaddr_t)frame;
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     memset(t->arch.fpu_buffer, 0, sizeof(t->arch.fpu_buffer));
     t->arch.fpu_states = (vaddr_t *)ROUNDUP(((vaddr_t)t->arch.fpu_buffer), 16);
 #endif
@@ -106,7 +106,7 @@ void arch_context_switch(thread_t *oldthread, thread_t *newthread)
 {
     //dprintf(DEBUG, "arch_context_switch: old %p (%s), new %p (%s)\n", oldthread, oldthread->name, newthread, newthread->name);
 
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
     fpu_context_switch(oldthread, newthread);
 #endif
 

--- a/platform/pc/interrupts.c
+++ b/platform/pc/interrupts.c
@@ -231,7 +231,7 @@ enum handler_return platform_irq(struct x86_iframe *frame)
             break;
 
         case INT_DEV_NA_EX:
-#ifdef X86_WITH_FPU
+#if X86_WITH_FPU
             fpu_dev_na_handler();
             break;
 #endif


### PR DESCRIPTION

With this patch, no compile failure issue when either X86_WITH_FPU not defined
or defined as 0(1).

Signed-off-by: Zhu, Bing <bing.zhu@intel.com>