### PR TITLE
[gfx][colour] Separate surface manipulation functions from colour tra…

### DIFF
--- a/include/lib/gfx.h
+++ b/include/lib/gfx.h
@@ -63,6 +63,7 @@ typedef struct gfx_surface {
 	uint alpha;
 
 	// function pointers
+	uint32_t (*translate_color)(uint32_t input);
 	void (*copyrect)(struct gfx_surface *, uint x, uint y, uint width, uint height, uint x2, uint y2);
 	void (*fillrect)(struct gfx_surface *, uint x, uint y, uint width, uint height, uint color);
 	void (*putpixel)(struct gfx_surface *, uint x, uint y, uint color);


### PR DESCRIPTION
…nslation functions.

Reduce code duplication in the future. `copyrect`, `fillrect`, and `putpixel` are identical regardless of the colour representation (8bit rgb vs 8bit mono). Shifting the responsibility of flattening colours away from these functions.